### PR TITLE
Update to accept_file error handling

### DIFF
--- a/iboot-loader.py
+++ b/iboot-loader.py
@@ -202,6 +202,10 @@ def accept_file(fd, fname):
         image_type = fd.read(0x30).decode()
     except UnicodeDecodeError:
         return 0
+    except AttributeError:
+        # When file is small, IDA will report error
+        # AttributeError: 'NoneType' object has no attribute 'decode'
+        return 0
 
     if image_type[:5] == "iBoot" or image_type[:4] in ["iBEC", "iBSS"]:
         return {"format": "iBoot (AArch64)", "processor": "arm"}


### PR DESCRIPTION
When looking at small shellcode dumped from memory, IDA would raise an exception text box:

![image](https://github.com/user-attachments/assets/0ba568ad-f983-4f0c-bd2a-a479bc00cf1b)

```
Traceback (most recent call last):
  File "/Users/XXXXXXX/.idapro/loaders/iboot-loader.py", line 202, in accept_file
    image_type= fd.read(0x30).decode()
              ^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'decode'
```

When I followed the logic in a Python interpreter (in IDA and externally) the offending code would return `b''` which could be decoded, but when IDA is loading the file the behavior is different. To prevent this error being provided multiple times, I've added handling for the `AttributeError` exception that could occur. 

I'm using IDA Pro Version 8.3.230608 macOS arm64